### PR TITLE
Fix AES-128 pipeline and add self-checking testbench

### DIFF
--- a/aes_control_fsm_pipeline.vhd
+++ b/aes_control_fsm_pipeline.vhd
@@ -6,14 +6,16 @@ use IEEE.STD_LOGIC_1164.ALL;
 
 entity AES_CONTROL_FSM_PIPELINE is
     generic (
-        PIPELINE_DEPTH : integer := 11 --  (11 thanh ghi cho AES-128)
+        -- Số chu kỳ trễ của toàn bộ pipeline. Với 11 thanh ghi giữa các tầng
+        -- của AES-128, độ trễ tổng là 12 chu kỳ (tính cả chu kỳ đầu vào).
+        PIPELINE_DEPTH : integer := 12
     );
     port (
         CLK             : in  std_logic;
         RESET           : in  std_logic;
-        DATA_VALID_IN   : in  std_logic; -- B�o c� plaintext 
-        DATA_VALID_OUT  : out std_logic; -- B�o c� ciphertext 
-        PIPELINE_ENABLE : out std_logic  -- T�n hieu cho ph�p hoat �ong cua c�c thanh ghi
+        DATA_VALID_IN   : in  std_logic; -- Báo có plaintext 
+        DATA_VALID_OUT  : out std_logic; -- Báo có ciphertext 
+        PIPELINE_ENABLE : out std_logic  -- Tín hieu cho phép hoat ðong cua các thanh ghi
     );
 end entity AES_CONTROL_FSM_PIPELINE;
 
@@ -27,18 +29,18 @@ architecture behavioral of AES_CONTROL_FSM_PIPELINE is
 
 begin
 
-    -- Process ch�nh �e dich chuyen bit valid
+    -- Process chính ðe dich chuyen bit valid
     valid_delay_proc: process(CLK, RESET)
     begin
         if RESET = '1' then
             valid_shifter <= (others => '0');
         elsif rising_edge(CLK) then
-            -- Dich phai v� ��a bit valid moi v�o
+            -- Dich phai và ðýa bit valid moi vào
             valid_shifter <= valid_shifter(PIPELINE_DEPTH - 2 downto 0) & DATA_VALID_IN;
         end if;
     end process;
 
-    -- �au ra valid l� bit cuoi c�ng cua thanh ghi dich
+    -- Ðau ra valid là bit cuoi cùng cua thanh ghi dich
     DATA_VALID_OUT <= valid_shifter(PIPELINE_DEPTH - 1);
 
 

--- a/aes_mixcolumns.vhd
+++ b/aes_mixcolumns.vhd
@@ -24,13 +24,13 @@ architecture dataflow of AES_MIXCOLUMNS is
 
 begin
 
-    -- T�ch 128 bit �au v�o th�nh 16 byte theo thu tu state array
+    -- Tách 128 bit ðau vào thành 16 byte theo thu tu state array
     -- (Byte 0 = MSB)
     byte_separator: for i in 0 to 15 generate
         s_in_bytes(i) <= DATA_IN_MIXCOL( (127-i*8) downto (120-i*8) );
     end generate;
 
-    -- T�nh gi� tri nh�n 2 cho moi byte
+    -- Tính giá tri nhân 2 cho moi byte
     xtime_gen: for i in 0 to 15 generate
         xtime_inst: component AES_XTIME
             port map(
@@ -39,13 +39,13 @@ begin
             );
     end generate;
 
-    -- Thuc hien nh�n ma tran cho 4 cot
+    -- Thuc hien nhân ma tran cho 4 cot
     mix_columns_gen: for c in 0 to 3 generate
-        -- Chu so cua 4 byte trong cot hien tai
-        constant b0 : integer := c;
-        constant b1 : integer := c + 4;
-        constant b2 : integer := c + 8;
-        constant b3 : integer := c + 12;
+        -- Chỉ số của 4 byte trong cột hiện tại (đánh theo cột)
+        constant b0 : integer := c*4;
+        constant b1 : integer := c*4 + 1;
+        constant b2 : integer := c*4 + 2;
+        constant b3 : integer := c*4 + 3;
     begin
         -- out[0] = (2*in[0]) xor (3*in[1]) xor (1*in[2]) xor (1*in[3])
         DATA_OUT_MIXCOL( (127-b0*8) downto (120-b0*8) ) <= s_xtime_bytes(b0) xor (s_xtime_bytes(b1) xor s_in_bytes(b1)) xor s_in_bytes(b2) xor s_in_bytes(b3);

--- a/aes_rabbit_core.vhd
+++ b/aes_rabbit_core.vhd
@@ -7,7 +7,7 @@ library work;
 use work.AES_MODE_PK.all;
 
 -- =================================================================
--- KHAI B¡O ENTITY
+-- KHAI B√ÅO ENTITY
 -- =================================================================
 entity AES_RABBIT_CORE is
     port(
@@ -28,7 +28,7 @@ end entity AES_RABBIT_CORE;
 ------------------------------------------------------------------
 architecture structural of AES_RABBIT_CORE is
 
-    -- 1. KHAI B¡O C¡C COMPONENT (trong architecture)
+    -- 1. KHAI B√ÅO C√ÅC COMPONENT (trong architecture)
     component AES_KEY_EXPANSION_128_PIPELINE is
         port (
             CLK            : in  std_logic;
@@ -75,11 +75,11 @@ architecture structural of AES_RABBIT_CORE is
         );
     end component;
 
-    -- 2. KHAI B¡O C¡C TÕN HIEU NOI BO (trong architecture)
+    -- 2. KHAI B√ÅO C√ÅC T√çN HIEU NOI BO (trong architecture)
     signal s_round_keys      : keyblock_128;
     signal s_pipeline_enable : std_logic;
 
-    -- Mang chua du lieu giua c·c tang pipeline
+    -- Mang chua du lieu giua c√°c tang pipeline
     type T_PIPE_ARRAY is array (0 to 11) of std_logic_vector(127 downto 0);
     signal pipe_data_in  : T_PIPE_ARRAY;
     signal pipe_data_out : T_PIPE_ARRAY;
@@ -108,7 +108,7 @@ begin
 
     -- 4. DATAPATH 
     
-    -- Tang au v‡o
+    -- Tang √∞au v√†o
     pipe_data_in(0) <= PLAINTEXT_IN;
 
     -- Tang 0: Initial AddKey
@@ -119,17 +119,15 @@ begin
             DATA_OUT => pipe_data_out(0)
         );
 
-    -- Thanh ghi giua tang 0 v‡ 1
+    -- Thanh ghi giua tang 0 v√† 1
     reg_pipe_0_proc: process(CLK)
     begin
         if rising_edge(CLK) then
-            if s_pipeline_enable = '1' then
-                pipe_data_in(1) <= pipe_data_out(0);
-            end if;
+            pipe_data_in(1) <= pipe_data_out(0);
         end if;
     end process;
 
-    -- T?ng 1 en 9
+    -- T?ng 1 √∞en 9
     Gen_Standard_Rounds: for i in 1 to 9 generate
     begin
         round_func_inst: component AES_ROUND_FUNCTION
@@ -142,14 +140,12 @@ begin
         reg_pipe_i_proc: process(CLK)
         begin
             if rising_edge(CLK) then
-                if s_pipeline_enable = '1' then
-                    pipe_data_in(i + 1) <= pipe_data_out(i);
-                end if;
+                pipe_data_in(i + 1) <= pipe_data_out(i);
             end if;
         end process;
     end generate Gen_Standard_Rounds;
 
-    -- Tang 10: (khÙng cÛ MixColumns)
+    -- Tang 10: (kh√¥ng c√≥ MixColumns)
     final_round_inst: component AES_FINAL_ROUND
         port map (
             DATA_IN      => pipe_data_in(10),
@@ -157,13 +153,11 @@ begin
             DATA_OUT     => pipe_data_out(10)
         );
 
-    -- Thanh ghi giua tang 10 v‡ 11
+    -- Thanh ghi giua tang 10 v√† 11
     reg_pipe_10_proc: process(CLK)
     begin
         if rising_edge(CLK) then
-            if s_pipeline_enable = '1' then
-                pipe_data_in(11) <= pipe_data_out(10);
-            end if;
+            pipe_data_in(11) <= pipe_data_out(10);
         end if;
     end process;
 

--- a/aes_subbytes.vhd
+++ b/aes_subbytes.vhd
@@ -29,11 +29,12 @@ architecture behaviour of AES_SUBBYTES is
         );
     end component;
 BEGIN
+    -- Mỗi byte trong state được xử lý theo thứ tự big-endian
     sbox_gen0: for i in 0 to 15 generate
-        sbox_inst0: component AES_SBOX -- Sửa ở đây
+        sbox_inst0: component AES_SBOX
             port map (
-                SBOX_IN  => data_in_sub(8*i+7 downto 8*i),
-                SBOX_OUT => data_out_sub(8*i+7 downto 8*i)
+                SBOX_IN  => DATA_IN_SUB(127 - i*8 downto 120 - i*8),
+                SBOX_OUT => DATA_OUT_SUB(127 - i*8 downto 120 - i*8)
             );
     end generate sbox_gen0;
     ------------------------------------------------------- 


### PR DESCRIPTION
## Summary
- align byte ordering across SubBytes, MixColumns, and pipeline register stages
- initialise key expansion registers and fix MixColumns column indexing
- extend pipeline depth and remove conditional register enables to allow full 10 rounds
- add self-checking testbench using FIPS-197 AES-128 vectors

## Testing
- `ghdl -a --std=08 --ieee=synopsys aes_mode_pkg.vhd aes_sbox.vhd aes_Xtime.vhd aes_subbytes.vhd aes_shiftrows.vhd aes_mixcolumns.vhd aes_addroundkey.vhd aes_initial_addkey.vhd aes_round_function.vhd aes_final_round.vhd aes_rcon.vhd aes_key_expansion_128_pipeline.vhd aes_control_fsm_pipeline.vhd aes_rabbit_core.vhd tb_aes_rabbit_core.vhd`
- `ghdl -e --std=08 --ieee=synopsys tb_aes_rabbit_core`
- `ghdl -r --std=08 --ieee=synopsys tb_aes_rabbit_core --stop-time=1us`


------
https://chatgpt.com/codex/tasks/task_b_6899f0bb95a48321b9af5f585ed04ce2