### PR TITLE
Align control FSM pipeline depth

### DIFF
--- a/aes_rabbit_core.vhd
+++ b/aes_rabbit_core.vhd
@@ -41,7 +41,7 @@ architecture structural of AES_RABBIT_CORE is
     end component;
 
     component AES_CONTROL_FSM_PIPELINE is
-        generic (PIPELINE_DEPTH : integer := 11);
+        generic (PIPELINE_DEPTH : integer := 12);
         port (
             CLK             : in  std_logic;
             RESET           : in  std_logic;


### PR DESCRIPTION
## Summary
- set AES_CONTROL_FSM_PIPELINE component default PIPELINE_DEPTH to 12

## Testing
- `ghdl -s -fsynopsys aes_mode_pkg.vhd aes_control_fsm_pipeline.vhd aes_rabbit_core.vhd`


------
https://chatgpt.com/codex/tasks/task_b_689a81bea9d48321aaba541db291b03f