### PR TITLE
Refactor AES key expansion into pipelined stages

### DIFF
--- a/aes_key_expansion_128_pipeline.vhd
+++ b/aes_key_expansion_128_pipeline.vhd
@@ -1,12 +1,19 @@
 -- File: aes_key_expansion_128_pipeline.vhd
 
-
 library IEEE;
 use IEEE.STD_LOGIC_1164.ALL;
 use IEEE.NUMERIC_STD.ALL;
+
 library work;
 use work.AES_MODE_PK.all;
 
+--!
+--!  AES‑128 key expansion with simple pipeline.
+--!  The original version iterated round by round using an FSM.
+--!  Here we split the design into a purely combinational chain and
+--!  pipeline registers so that all 10 round keys are produced in
+--!  parallel after 10 clock cycles.
+--!
 entity AES_KEY_EXPANSION_128_PIPELINE is
     port (
         CLK            : in  std_logic;
@@ -18,109 +25,122 @@ entity AES_KEY_EXPANSION_128_PIPELINE is
     );
 end entity AES_KEY_EXPANSION_128_PIPELINE;
 
-architecture behavioral of AES_KEY_EXPANSION_128_PIPELINE is
+architecture rtl of AES_KEY_EXPANSION_128_PIPELINE is
 
+    --------------------------------------------------------------------
+    --  Components
+    --------------------------------------------------------------------
     component AES_SBOX is
-        port ( SBOX_IN : in std_logic_vector(7 downto 0); SBOX_OUT : out std_logic_vector(7 downto 0) );
+        port (
+            SBOX_IN  : in  std_logic_vector(7 downto 0);
+            SBOX_OUT : out std_logic_vector(7 downto 0)
+        );
     end component;
-    component AES_RCON is
-        port ( RCON_I : in std_logic_vector(3 downto 0); RCON_O : out std_logic_vector(7 downto 0) );
-    end component;
 
-    type T_FSM_STATE is (S_IDLE, S_CALC);
-    --
-    -- Các thanh ghi trạng thái cần có giá trị khởi tạo rõ ràng
-    -- để tránh cảnh báo "metavalue" khi mô phỏng và bảo đảm
-    -- hành vi xác định ngay từ thời điểm 0 ns.
-    --
-    signal current_state : T_FSM_STATE := S_IDLE;
+    --------------------------------------------------------------------
+    --  Constant Rcon values for rounds 1..10
+    --------------------------------------------------------------------
+    type rcon_array_t is array (0 to 9) of std_logic_vector(7 downto 0);
+    constant RCON_VALUES : rcon_array_t := (
+        x"01", x"02", x"04", x"08", x"10",
+        x"20", x"40", x"80", x"1B", x"36"
+    );
 
-    -- Đếm số vòng khóa đã sinh ra (0..10 cho AES‑128)
-    signal round_counter  : integer range 0 to 11 := 0;
-
-    -- Lưu trữ toàn bộ 11 round‑key
+    --------------------------------------------------------------------
+    --  Pipeline register bank and valid shift register
+    --------------------------------------------------------------------
     signal round_keys_reg : keyblock_128 := (others => (others => '0'));
+    signal valid_shreg    : std_logic_vector(10 downto 0) := (others => '0');
 
-    -- Tín hi?u cho logic t? h?p
-    signal temp_word, rot_word, sub_word_out : std_logic_vector(31 downto 0);
-    signal rcon_out       : std_logic_vector(7 downto 0);
-    signal rcon_in_signal : std_logic_vector(3 downto 0);
-    signal prev_w0, prev_w1, prev_w2, prev_w3 : std_logic_vector(31 downto 0);
-    signal next_w0, next_w1, next_w2, next_w3 : std_logic_vector(31 downto 0);
+    --------------------------------------------------------------------
+    --  Signals for combinational stages
+    --------------------------------------------------------------------
+    type word_array is array (0 to 9) of std_logic_vector(31 downto 0);
+    type key_array  is array (0 to 9) of std_logic_vector(127 downto 0);
+
+    signal rot_word    : word_array;
+    signal sub_word    : word_array;
+    signal temp_word   : word_array;
+    signal next_w0     : word_array;
+    signal next_w1     : word_array;
+    signal next_w2     : word_array;
+    signal next_w3     : word_array;
+    signal next_key    : key_array;
 
 begin
-    -- Gán ðau ra truc tiep tu thanh ghi
-    ROUND_KEYS_OUT <= round_keys_reg;
+    --------------------------------------------------------------------
+    --  Combinational expansion for each pipeline stage
+    --------------------------------------------------------------------
+    stage_gen : for i in 0 to 9 generate
+        -- Extract previous words from register bank
+        constant W0_H : integer := 127;
+        constant W0_L : integer := 96;
+        constant W1_H : integer := 95;
+        constant W1_L : integer := 64;
+        constant W2_H : integer := 63;
+        constant W2_L : integer := 32;
+        constant W3_H : integer := 31;
+        constant W3_L : integer := 0;
+    begin
+        -- RotWord
+        rot_word(i) <= round_keys_reg(i)(W3_L+23 downto W3_L) &
+                       round_keys_reg(i)(W3_H downto W3_H-7);
 
-    -- =============================================================
-    -- 1.(COMBINATIONAL LOGIC)
-    -- =============================================================
-    -- Lay các word cua khóa vong trýoc ðó tu thanh ghi
-    prev_w0 <= round_keys_reg(round_counter - 1)(127 downto 96) when round_counter > 0 else (others => '0');
-    prev_w1 <= round_keys_reg(round_counter - 1)(95 downto 64)  when round_counter > 0 else (others => '0');
-    prev_w2 <= round_keys_reg(round_counter - 1)(63 downto 32)  when round_counter > 0 else (others => '0');
-    prev_w3 <= round_keys_reg(round_counter - 1)(31 downto 0)   when round_counter > 0 else (others => '0');
+        -- SubWord using four SBOXes
+        sbox_gen : for j in 0 to 3 generate
+            sbox_inst : AES_SBOX
+                port map (
+                    SBOX_IN  => rot_word(i)(8*j+7 downto 8*j),
+                    SBOX_OUT => sub_word(i)(8*j+7 downto 8*j)
+                );
+        end generate;
 
-    -- RotWord
-    rot_word <= prev_w3(23 downto 0) & prev_w3(31 downto 24);
+        -- Rcon xor
+        temp_word(i) <= sub_word(i) xor (RCON_VALUES(i) & x"000000");
 
-    -- SubWord
-    sbox_gen: for i in 0 to 3 generate
-        sbox_inst: component AES_SBOX port map (rot_word(8*i + 7 downto 8*i), sub_word_out(8*i + 7 downto 8*i));
-    end generate;
+        -- Next words
+        next_w0(i) <= round_keys_reg(i)(W0_H downto W0_L) xor temp_word(i);
+        next_w1(i) <= round_keys_reg(i)(W1_H downto W1_L) xor next_w0(i);
+        next_w2(i) <= round_keys_reg(i)(W2_H downto W2_L) xor next_w1(i);
+        next_w3(i) <= round_keys_reg(i)(W3_H downto W3_L) xor next_w2(i);
 
-    -- Rcon
-    rcon_in_signal <= std_logic_vector(to_unsigned(round_counter, 4));
-    rcon_inst: component AES_RCON port map (rcon_in_signal, rcon_out);
+        -- Concatenate for next round key
+        next_key(i) <= next_w0(i) & next_w1(i) & next_w2(i) & next_w3(i);
+    end generate stage_gen;
 
-    -- temp_word
-    temp_word <= sub_word_out xor (rcon_out & x"000000");
-
-    -- Tính các word tiep theo
-    next_w0 <= prev_w0 xor temp_word;
-    next_w1 <= prev_w1 xor next_w0;
-    next_w2 <= prev_w2 xor next_w1;
-    next_w3 <= prev_w3 xor next_w2;
-
-
-    -- =============================================================
-    -- 2. (SEQUENTIAL LOGIC)
-    -- =============================================================
-    -- Process này xu ly tat ca các thanh ghi và trang thái cua FSM.
-    fsm_proc: process(CLK)
+    --------------------------------------------------------------------
+    --  Sequential pipeline register updates
+    --------------------------------------------------------------------
+    process (CLK)
     begin
         if rising_edge(CLK) then
             if RESET = '1' then
-                current_state  <= S_IDLE;
-                KEYS_READY     <= '1';
-                round_counter  <= 0;
                 round_keys_reg <= (others => (others => '0'));
+                valid_shreg    <= (others => '0');
             else
-                case current_state is
-                    when S_IDLE =>
-                        KEYS_READY <= '1';
-                        if KEY_VALID = '1' then
-                            -- nap khóa goc và chuyen trang thái
-                            round_keys_reg(0) <= KEY_IN;
-                            round_counter     <= 1;
-                            KEYS_READY        <= '0';
-                            current_state     <= S_CALC;
-                        end if;
+                -- load initial key when valid
+                if KEY_VALID = '1' then
+                    round_keys_reg(0) <= KEY_IN;
+                end if;
 
-                    when S_CALC =>
-                        -- Lýu khóa vong vua ðýoc tính toán 
-                        round_keys_reg(round_counter) <= next_w0 & next_w1 & next_w2 & next_w3;
+                -- propagate through pipeline when data valid
+                for k in 0 to 9 loop
+                    if valid_shreg(k) = '1' then
+                        round_keys_reg(k+1) <= next_key(k);
+                    end if;
+                end loop;
 
-                        -- Kiem tra 
-                        if round_counter = 10 then
-                            current_state <= S_IDLE;
-                          
-                        else
-                            round_counter <= round_counter + 1;
-                        end if;
-                end case;
+                -- shift valid register
+                valid_shreg(0) <= KEY_VALID;
+                for k in 1 to 10 loop
+                    valid_shreg(k) <= valid_shreg(k-1);
+                end loop;
             end if;
         end if;
-    end process fsm_proc;
+    end process;
 
-end architecture behavioral;
+    ROUND_KEYS_OUT <= round_keys_reg;
+    KEYS_READY     <= valid_shreg(10);
+
+end architecture rtl;
+


### PR DESCRIPTION
## Summary
- Refactor AES-128 key schedule into fully pipelined stages producing all 10 round keys concurrently
- Replace FSM with combinational chain and per-round registers using a valid shift register

## Testing
- `ghdl -a -fsynopsys aes_mode_pkg.vhd aes_sbox.vhd aes_key_expansion_128_pipeline.vhd`
- `ghdl -e -fsynopsys AES_KEY_EXPANSION_128_PIPELINE`


------
https://chatgpt.com/codex/tasks/task_b_689a81c093748321a06e76f55bfa16d5